### PR TITLE
Bug#4181 fixed incorrectness of Previous\Next links in news articles

### DIFF
--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -104,12 +104,12 @@ class News extends Model
     
     public function previous()
     {
-        return News::where('id', '<', $this->id)->orderBy('id','desc')->first();
+        return News::where('id', '>', $this->id)->orderBy('id','asc')->first();
     }
     
     public function next()
     {
-        return News::where('id', '>', $this->id)->orderBy('id','asc')->first();
+        return News::where('id', '<', $this->id)->orderBy('id','desc')->first();
     }
     
     public function shortDescription()


### PR DESCRIPTION
Implementations of "previous" and "next" methods in News model were swapped to fix incorrect behavior when you try to switch next or previous article. 